### PR TITLE
removed deprecated chunking information

### DIFF
--- a/docs/door43.rst
+++ b/docs/door43.rst
@@ -64,8 +64,6 @@ Much of the catalog (see :ref:`door43-example` below) should be self explanatory
 
 * version numbers in the urls such as ``v7`` indicate the version of the resource or asset. This is not the same as the api version seen in the catalog url.
 
-* ``languages`` → ``resources`` → ``projects`` → ``chunks_url``: provides a catalog that maps divisions in the text with various versification systems. See ref:`door43-chunks` for more information.
-
 * ``languages`` → ``versification_labels``: provides human readable labels to the different versification systems available in the catalog. These labels may be used, for example, when a user imports raw content such as USFM and are given the opportunity to select the appropriate versification system.
 
 * ``languages`` → ``resources`` → ``modified``: gives the date the resource was last modified according to the translator.
@@ -464,7 +462,6 @@ Example
                   "categories": [
                     "bible-ot"
                   ],
-                  "chunks_url": "https://cdn.door43.org/bible/gen/v3/chunks.json",
                   "formats": [
                     {
                       "format": "text/usfm",
@@ -493,7 +490,6 @@ Example
                   "categories": [
                     "bible-ot"
                   ],
-                  "chunks_url": "https://cdn.door43.org/bible/exo/v3/chunks.json",
                   "formats": [
                     {
                       "format": "text/usfm",
@@ -522,7 +518,6 @@ Example
                   "categories": [
                     "bible-ot"
                   ],
-                  "chunks_url": "https://cdn.door43.org/bible/mal/v3/chunks.json",
                   "formats": [
                     {
                       "format": "text/usfm",
@@ -551,7 +546,6 @@ Example
                   "categories": [
                     "bible-nt"
                   ],
-                  "chunks_url": "https://cdn.door43.org/bible/mat/v3/chunks.json",
                   "formats": [
                     {
                       "format": "text/usfm",
@@ -580,7 +574,6 @@ Example
                   "categories": [
                     "bible-nt"
                   ],
-                  "chunks_url": "https://cdn.door43.org/bible/mrk/v3/chunks.json",
                   "formats": [
                     {
                       "format": "text/usfm",
@@ -609,7 +602,6 @@ Example
                   "categories": [
                     "bible-nt"
                   ],
-                  "chunks_url": "https://cdn.door43.org/bible/luk/v3/chunks.json",
                   "formats": [
                     {
                       "format": "text/usfm",
@@ -638,7 +630,6 @@ Example
                   "categories": [
                     "bible-nt"
                   ],
-                  "chunks_url": "https://cdn.door43.org/bible/rev/v3/chunks.json",
                   "formats": [
                     {
                       "format": "text/usfm",
@@ -692,49 +683,3 @@ Example
       ]
     }
 
-
-.. _door43-chunks:
-
-Chunk Markers
--------------
-
-Chunks markers define how a book is to be chunked (that is, divided) according to a particular versification system.  They are available in the :ref:`door43` via the ``chunks_url`` key for each project.
-
-
-Definitions
-~~~~~~~~~~~
-
-* the ``versification-system-id`` matches the slug stored in the `Resource Container manifest <http://resource-container.readthedocs.io/en/latest/manifest.html>`_ as well as the label defined in the :ref:`door43`.
-
-* ``first_verses`` indicates the start of chunks in the given chapter. Chunks will include the subsequent verses up to but not including the next first verse.
-
-
-Example
-~~~~~~~
-
-Chunks are defined according to versification systems and are grouped accordingly
-
-.. include:: /includes/json_snippet.txt
-.. code-block:: json
-
-    {
-      "some-versification-system-id": [
-        {
-          "chapter": 1,
-          "first_verses": [1, 5, 8, 11, 13, 17, 20, 24, 28, 32, 34, 38, 41, 43, 46, 49, 51]
-        },
-        {
-          "chapter": 2,
-          "first_verses": [1, 3, 5, 9, 13, 16, 18, 21, 23, 25, 29, 34, 36, 39, 42, 45, 48, 50, 52, 54]
-        },
-        {
-          "chapter": 3,
-          "first_verses": [1, 4, 6, 10, 13, 15, 17, 19, 22]
-        },
-        {
-          "chapter": 4,
-          "first_verses": [1, 3, 5, 9, 11, 13, 17, 19, 21, 24, 27, 29, 32, 34, 39, 42]
-        }
-      ],
-      "another-versification-system-id": [...]
-    }


### PR DESCRIPTION
The chunks_url and files describing chunks are deprecated in the v3 api. tS v2 will continue to use chunk marker files however the v3 api will rely on s5 markers within the text.